### PR TITLE
16 cache upstream

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,10 @@ The following environment variables are supported:
     The OpenID Connect configuration refresh interval. See `Time based settings`_
 ``UPSTREAM_TOKENINFO_URL``
     URL of upstream OAuth 2 token info for non-JWT Bearer tokens.
+``UPSTREAM_CACHE_MAX_SIZE``
+    Maximum number of entries for upstream token cache. It defaults to 10000.
+``UPSTREAM_CACHE_TTL``
+    The TTL for upstream token cache entries. It defaults to 60 seconds. See `Time based settings`_
 ``LISTEN_ADDRESS``
     The address for the application listener. It defaults to ':9021'
 ``METRICS_LISTEN_ADDRESS``

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,22 @@ Some of the above settings accept time based definitions. Those definitions can 
 For ex., '10s' for 10 seconds, '1h10m' for 1 hour and 10 minutes, '100ms' for 100 milliseconds.
 A simple numeric value is interpreted as Seconds. For ex., '30' is interpreted as 30 seconds.
 
+Metrics
+=======
+
+Metrics are exposed by default on port 9020 "/metrics". They include:
+
+``planb.openidprovider.numkeys``
+    Number of public keys in memory.
+``planb.tokeninfo.proxy``
+    Timer for the proxy handler (includes cached results and upstream calls).
+``planb.tokeninfo.proxy.cache.hits``
+    Number of upstream cache hits.
+``planb.tokeninfo.proxy.cache.misses``
+    Number of upstream cache misses.
+``planb.tokeninfo.proxy.upstream``
+    Timer for calls to the upstream tokeninfo. Cached responses are not measured here.
+
 .. _Plan B OpenID Connect Provider: https://github.com/zalando/planb-provider
 .. _Plan B Revocation Service: https://github.com/zalando/planb-revocation
 .. _JOSE header: https://tools.ietf.org/html/rfc7515#section-4

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Current features:
 
 * Download public keys (`set of JWKs`_) from OpenID provider
 * Verify signed JWT tokens using the right public key (identified by "kid" `JOSE header`_)
+* Proxy to upstream tokeninfo for non-JWT tokens and cache the response
 
 Planned features:
 

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ The following environment variables are supported:
 ``UPSTREAM_CACHE_MAX_SIZE``
     Maximum number of entries for upstream token cache. It defaults to 10000.
 ``UPSTREAM_CACHE_TTL``
-    The TTL for upstream token cache entries. It defaults to 60 seconds. See `Time based settings`_
+    The TTL for upstream token cache entries. It defaults to 60 seconds. Zero will disable the cache. See also `Time based settings`_
 ``LISTEN_ADDRESS``
     The address for the application listener. It defaults to ':9021'
 ``METRICS_LISTEN_ADDRESS``

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,8 @@ Metrics are exposed by default on port 9020 "/metrics". They include:
     Number of upstream cache hits.
 ``planb.tokeninfo.proxy.cache.misses``
     Number of upstream cache misses.
+``planb.tokeninfo.proxy.cache.expirations``
+    Number of upstream cache misses because of expiration.
 ``planb.tokeninfo.proxy.upstream``
     Timer for calls to the upstream tokeninfo. Cached responses are not measured here.
 

--- a/handlers/metrics/handler.go
+++ b/handlers/metrics/handler.go
@@ -15,8 +15,8 @@ var Default = Handler(metrics.DefaultRegistry)
 
 // ServeHTTP returns status 200 and writes metrics from the registry as JSON
 func (h *metricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	metrics.WriteJSONOnce(h.registry, w)
 }
 

--- a/handlers/tokeninfo/proxy/handler.go
+++ b/handlers/tokeninfo/proxy/handler.go
@@ -75,7 +75,7 @@ func (h *tokenInfoProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 		rw := newResponseBuffer(w)
 		rw.Header().Set("X-Cache", "MISS")
 		h.upstream.ServeHTTP(rw, req)
-		if rw.StatusCode == 200 {
+		if rw.StatusCode == 200 && h.cacheTTL > 0 {
 			h.cache.Set(token, rw.Buffer.Bytes(), h.cacheTTL)
 		}
 		t := metrics.DefaultRegistry.GetOrRegister("planb.tokeninfo.proxy", metrics.NewTimer).(metrics.Timer)

--- a/handlers/tokeninfo/proxy/handler_test.go
+++ b/handlers/tokeninfo/proxy/handler_test.go
@@ -75,3 +75,46 @@ func TestHostHeader(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://example.com/oauth2/tokeninfo?access_token=foo", nil)
 	h.ServeHTTP(w, r)
 }
+
+func TestCache(t *testing.T) {
+	var upstream string
+	var counter int
+
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(testTokenInfo))
+		counter++
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	upstream = fmt.Sprintf("http://%s", server.Listener.Addr())
+	url, _ := url.Parse(upstream)
+	h := NewTokenInfoProxyHandler(url)
+	for _, it := range []struct {
+		query    string
+		wantCode int
+		wantBody string
+	}{
+		{"/oauth2/tokeninfo?access_token=foo", http.StatusOK, testTokenInfo},
+		{"/oauth2/tokeninfo?access_token=bar", http.StatusOK, testTokenInfo},
+		{"/oauth2/tokeninfo?access_token=foo", http.StatusOK, testTokenInfo},
+	} {
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("GET", "http://example.com"+it.query, nil)
+		h.ServeHTTP(w, r)
+
+		if w.Code != it.wantCode {
+			t.Errorf("Wrong status code. Wanted %d, got %d", it.wantCode, w.Code)
+		}
+
+		if w.Body.String() != it.wantBody {
+			t.Errorf("Wrong response body. Wanted %q, got %s", it.wantBody, w.Body.String())
+		}
+	}
+	if counter > 2 {
+		t.Errorf("Second request for 'foo' token should have been cached, but we got %d calls to upstream", counter)
+	}
+}

--- a/handlers/tokeninfo/proxy/handler_test.go
+++ b/handlers/tokeninfo/proxy/handler_test.go
@@ -93,7 +93,7 @@ func TestCache(t *testing.T) {
 
 	upstream = fmt.Sprintf("http://%s", server.Listener.Addr())
 	url, _ := url.Parse(upstream)
-	h := NewTokenInfoProxyHandler(url, 10, time.Millisecond)
+	h := NewTokenInfoProxyHandler(url, 10, 200*time.Millisecond)
 	for _, it := range []struct {
 		query     string
 		wantCode  int
@@ -122,5 +122,53 @@ func TestCache(t *testing.T) {
 	}
 	if counter > 2 {
 		t.Errorf("Second request for 'foo' token should have been cached, but we got %d calls to upstream", counter)
+	}
+}
+
+func TestCacheDisabled(t *testing.T) {
+	var upstream string
+	var counter int
+
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(testTokenInfo))
+		counter++
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	upstream = fmt.Sprintf("http://%s", server.Listener.Addr())
+	url, _ := url.Parse(upstream)
+	h := NewTokenInfoProxyHandler(url, 10, 0)
+	for _, it := range []struct {
+		query     string
+		wantCode  int
+		wantBody  string
+		wantCache string
+	}{
+		{"/oauth2/tokeninfo?access_token=foo", http.StatusOK, testTokenInfo, "MISS"},
+		{"/oauth2/tokeninfo?access_token=bar", http.StatusOK, testTokenInfo, "MISS"},
+		{"/oauth2/tokeninfo?access_token=foo", http.StatusOK, testTokenInfo, "MISS"},
+	} {
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("GET", "http://example.com"+it.query, nil)
+		h.ServeHTTP(w, r)
+
+		if w.Code != it.wantCode {
+			t.Errorf("Wrong status code. Wanted %d, got %d", it.wantCode, w.Code)
+		}
+
+		if w.Body.String() != it.wantBody {
+			t.Errorf("Wrong response body. Wanted %q, got %s", it.wantBody, w.Body.String())
+		}
+
+		if w.Header().Get("X-Cache") != it.wantCache {
+			t.Errorf("Wrong cache header. Wanted %q, got %s", it.wantCache, w.Header().Get("X-Cache"))
+		}
+	}
+	if counter < 3 {
+		t.Errorf("Second request for 'foo' token should NOT have been cached, but we only got %d calls to upstream", counter)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	ht.UserAgent = fmt.Sprintf("%v/%s", os.Args[0], version)
 	setupMetrics(settings)
 
-	ph := tokeninfoproxy.NewTokenInfoProxyHandler(settings.UpstreamTokenInfoURL)
+	ph := tokeninfoproxy.NewTokenInfoProxyHandler(settings.UpstreamTokenInfoURL, settings.UpstreamCacheMaxSize, settings.UpstreamCacheTTL)
 	kl := openid.NewCachingOpenIDProviderLoader(settings.OpenIDProviderConfigurationURL)
 	jh := jwthandler.New(kl)
 

--- a/options/options.go
+++ b/options/options.go
@@ -78,11 +78,11 @@ func LoadFromEnvironment() error {
 		settings.MetricsListenAddress = s
 	}
 
-	if i := getInt("UPSTREAM_CACHE_MAX_SIZE", 0); i > 0 {
+	if i := getInt("UPSTREAM_CACHE_MAX_SIZE", -1); i > -1 {
 		settings.UpstreamCacheMaxSize = int64(i)
 	}
 
-	if d := getDuration("UPSTREAM_CACHE_TTL", 0); d > 0 {
+	if d := getDuration("UPSTREAM_CACHE_TTL", -1); d > -1 {
 		settings.UpstreamCacheTTL = d
 	}
 

--- a/options/options.go
+++ b/options/options.go
@@ -13,6 +13,8 @@ type Settings struct {
 	ListenAddress                  string
 	MetricsListenAddress           string
 	UpstreamTokenInfoURL           *url.URL
+	UpstreamCacheMaxSize           int64
+	UpstreamCacheTTL               time.Duration
 	OpenIDProviderConfigurationURL *url.URL
 	OpenIDProviderRefreshInterval  time.Duration
 	HTTPClientTimeout              time.Duration
@@ -22,6 +24,8 @@ type Settings struct {
 const (
 	defaultListenAddress         = ":9021"
 	defaultMetricsListenAddress  = ":9020"
+	defaultUpstreamCacheMaxSize  = 10000
+	defaultUpstreamCacheTTL      = 60 * time.Second
 	defaultOpenIDRefreshInterval = 30 * time.Second
 	defaultHTTPClientTimeout     = 10 * time.Second
 	defaultHTTPClientTLSTimeout  = 10 * time.Second
@@ -36,6 +40,8 @@ func defaultSettings() *Settings {
 	return &Settings{
 		ListenAddress:                 defaultListenAddress,
 		MetricsListenAddress:          defaultMetricsListenAddress,
+		UpstreamCacheMaxSize:          defaultUpstreamCacheMaxSize,
+		UpstreamCacheTTL:              defaultUpstreamCacheTTL,
 		OpenIDProviderRefreshInterval: defaultOpenIDRefreshInterval,
 		HTTPClientTimeout:             defaultHTTPClientTimeout,
 		HTTPClientTLSTimeout:          defaultHTTPClientTLSTimeout,
@@ -70,6 +76,14 @@ func LoadFromEnvironment() error {
 
 	if s := getString("METRICS_LISTEN_ADDRESS", ""); s != "" {
 		settings.MetricsListenAddress = s
+	}
+
+	if i := getInt("UPSTREAM_CACHE_MAX_SIZE", 0); i > 0 {
+		settings.UpstreamCacheMaxSize = int64(i)
+	}
+
+	if d := getDuration("UPSTREAM_CACHE_TTL", 0); d > 0 {
+		settings.UpstreamCacheTTL = d
 	}
 
 	if d := getDuration("OPENID_PROVIDER_REFRESH_INTERVAL", 0); d > 0 {

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -282,6 +282,27 @@ func TestLoading(t *testing.T) {
 			},
 			false,
 		},
+		{
+			map[string]string{
+				"UPSTREAM_TOKENINFO_URL":            "http://example.com",
+				"UPSTREAM_CACHE_MAX_SIZE":           "0",
+				"UPSTREAM_CACHE_TTL":                "0",
+				"OPENID_PROVIDER_CONFIGURATION_URL": "http://example.com",
+				"HTTP_CLIENT_TLS_TIMEOUT":           "10ms",
+			},
+			&Settings{
+				UpstreamTokenInfoURL:           exampleCom,
+				OpenIDProviderConfigurationURL: exampleCom,
+				UpstreamCacheMaxSize:           0,
+				UpstreamCacheTTL:               0,
+				HTTPClientTimeout:              defaultHTTPClientTimeout,
+				HTTPClientTLSTimeout:           10 * time.Millisecond,
+				OpenIDProviderRefreshInterval:  defaultOpenIDRefreshInterval,
+				ListenAddress:                  defaultListenAddress,
+				MetricsListenAddress:           defaultMetricsListenAddress,
+			},
+			false,
+		},
 	} {
 		os.Clearenv()
 		for k, v := range test.env {

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -175,6 +175,8 @@ func TestLoading(t *testing.T) {
 			&Settings{
 				UpstreamTokenInfoURL:           exampleCom,
 				OpenIDProviderConfigurationURL: exampleCom,
+				UpstreamCacheMaxSize:           defaultUpstreamCacheMaxSize,
+				UpstreamCacheTTL:               defaultUpstreamCacheTTL,
 				HTTPClientTimeout:              defaultHTTPClientTimeout,
 				HTTPClientTLSTimeout:           defaultHTTPClientTLSTimeout,
 				OpenIDProviderRefreshInterval:  defaultOpenIDRefreshInterval,
@@ -192,6 +194,8 @@ func TestLoading(t *testing.T) {
 			&Settings{
 				UpstreamTokenInfoURL:           exampleCom,
 				OpenIDProviderConfigurationURL: exampleCom,
+				UpstreamCacheMaxSize:           defaultUpstreamCacheMaxSize,
+				UpstreamCacheTTL:               defaultUpstreamCacheTTL,
 				HTTPClientTimeout:              defaultHTTPClientTimeout,
 				HTTPClientTLSTimeout:           defaultHTTPClientTLSTimeout,
 				OpenIDProviderRefreshInterval:  defaultOpenIDRefreshInterval,
@@ -209,6 +213,8 @@ func TestLoading(t *testing.T) {
 			&Settings{
 				UpstreamTokenInfoURL:           exampleCom,
 				OpenIDProviderConfigurationURL: exampleCom,
+				UpstreamCacheMaxSize:           defaultUpstreamCacheMaxSize,
+				UpstreamCacheTTL:               defaultUpstreamCacheTTL,
 				HTTPClientTimeout:              defaultHTTPClientTimeout,
 				HTTPClientTLSTimeout:           defaultHTTPClientTLSTimeout,
 				OpenIDProviderRefreshInterval:  defaultOpenIDRefreshInterval,
@@ -226,6 +232,8 @@ func TestLoading(t *testing.T) {
 			&Settings{
 				UpstreamTokenInfoURL:           exampleCom,
 				OpenIDProviderConfigurationURL: exampleCom,
+				UpstreamCacheMaxSize:           defaultUpstreamCacheMaxSize,
+				UpstreamCacheTTL:               defaultUpstreamCacheTTL,
 				HTTPClientTimeout:              defaultHTTPClientTimeout,
 				HTTPClientTLSTimeout:           defaultHTTPClientTLSTimeout,
 				OpenIDProviderRefreshInterval:  time.Minute,
@@ -243,6 +251,8 @@ func TestLoading(t *testing.T) {
 			&Settings{
 				UpstreamTokenInfoURL:           exampleCom,
 				OpenIDProviderConfigurationURL: exampleCom,
+				UpstreamCacheMaxSize:           defaultUpstreamCacheMaxSize,
+				UpstreamCacheTTL:               defaultUpstreamCacheTTL,
 				HTTPClientTimeout:              time.Millisecond,
 				HTTPClientTLSTimeout:           defaultHTTPClientTLSTimeout,
 				OpenIDProviderRefreshInterval:  defaultOpenIDRefreshInterval,
@@ -254,12 +264,16 @@ func TestLoading(t *testing.T) {
 		{
 			map[string]string{
 				"UPSTREAM_TOKENINFO_URL":            "http://example.com",
+				"UPSTREAM_CACHE_MAX_SIZE":           "123456789",
+				"UPSTREAM_CACHE_TTL":                "17s",
 				"OPENID_PROVIDER_CONFIGURATION_URL": "http://example.com",
 				"HTTP_CLIENT_TLS_TIMEOUT":           "10ms",
 			},
 			&Settings{
 				UpstreamTokenInfoURL:           exampleCom,
 				OpenIDProviderConfigurationURL: exampleCom,
+				UpstreamCacheMaxSize:           123456789,
+				UpstreamCacheTTL:               17 * time.Second,
 				HTTPClientTimeout:              defaultHTTPClientTimeout,
 				HTTPClientTLSTimeout:           10 * time.Millisecond,
 				OpenIDProviderRefreshInterval:  defaultOpenIDRefreshInterval,


### PR DESCRIPTION
Simple configurable upstream token cache (max size 10000 and TTL 60 seconds).

Using https://github.com/karlseguin/ccache/ (I don't want to copy Hanno's code and this one uses buckets to have higher concurrency).

This will also add a (more or less standard) `X-Cache` header with either "MISS" or "HIT".

