### PR TITLE
IsJWTRevoked (token): flip signs when checking issued_before and iat

### DIFF
--- a/revoke/revokeprovider.go
+++ b/revoke/revokeprovider.go
@@ -123,7 +123,7 @@ func (crp *CachingRevokeProvider) IsJWTRevoked(j *jwt.Token) bool {
 	// check token revocation
 	th := hashTokenClaim(j.Raw)
 	if r := crp.cache.Get(th); r != nil {
-		if val, ok := r.(*Revocation).Data["issued_before"]; ok && val.(int) < iat {
+		if val, ok := r.(*Revocation).Data["issued_before"]; ok && val.(int) > iat {
 			countRevocations(REVOCATION_TYPE_TOKEN)
 			return true
 		}

--- a/revoke/revokeprovider_test.go
+++ b/revoke/revokeprovider_test.go
@@ -45,8 +45,8 @@ func TestIsJWTRevoked(t *testing.T) {
 	// token
 	revData := make(map[string]interface{})
 	revData["token_hash"] = hashTokenClaim(rawJwt)
-	revData["revoked_at"] = 300000
-	revData["issued_before"] = 300000
+	revData["revoked_at"] = 500000
+	revData["issued_before"] = 500000
 	rev := &Revocation{Type: REVOCATION_TYPE_TOKEN, Data: revData, Timestamp: 300000}
 	crp.cache.Add(rev)
 
@@ -82,7 +82,7 @@ func TestIsJWTRevoked(t *testing.T) {
 		t.Errorf("Token should be revoked. %#v", jt)
 	}
 
-	tc["iat"] = 250000.0
+	tc["iat"] = 550000.0
 	jt = &jwt.Token{Raw: rawJwt, Claims: tc}
 	if crp.IsJWTRevoked(jt) {
 		t.Errorf("Token should not be revoked. %#v", jt)
@@ -178,7 +178,7 @@ func TestIsJWTRevokedMissingCacheFields(t *testing.T) {
 	// token
 	tc := make(map[string]interface{})
 	tc[sub] = subVal
-	tc["iat"] = 400000.0
+	tc["iat"] = 200000.0
 	jt := &jwt.Token{Raw: rawJwt, Claims: tc}
 
 	if crp.IsJWTRevoked(jt) {


### PR DESCRIPTION
isJwtRevoked - token - looking at 'iat' as if the revocation was issued_after instead of issued_before.