### PR TITLE
#60 Revocations with same claim must check IssuedBefore time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 scm-source.json
 planb-tokeninfo
 run.sh
-
+.vscode
 *.iml
 .idea/
 *.swp

--- a/revoke/caching_test.go
+++ b/revoke/caching_test.go
@@ -299,4 +299,61 @@ func TestUpdateClaimNames(t *testing.T) {
 	}
 }
 
+// see https://github.com/zalando/planb-tokeninfo/issues/60
+func TestCacheIgnoresOlderCollidingRevocations(t *testing.T) {
+	cache := NewCache()
+
+	revData2 := make(map[string]interface{})
+	revData2["value_hash"] = "hash"
+	revData2["names"] = "c1"
+	revData2["revoked_at"] = 124
+	revData2["issued_before"] = 124
+	rev2 := &Revocation{Type: REVOCATION_TYPE_CLAIM, Data: revData2}
+	cache.Add(rev2)
+
+	revData := make(map[string]interface{})
+	revData["value_hash"] = "hash"
+	revData["revoked_at"] = 123
+	revData["names"] = "c1"
+	revData["issued_before"] = 123
+
+	rev1 := &Revocation{Type: REVOCATION_TYPE_CLAIM, Data: revData}
+
+	cache.Add(rev1)
+
+	storedData := cache.Get("hash")
+
+	if storedData.(*Revocation).Data["issued_before"].(int) == 123 {
+		t.Errorf("Should not override revocation with same claim and older issued_before than current cached one.")
+	}
+}
+
+// see https://github.com/zalando/planb-tokeninfo/issues/60
+func TestCacheUpdatesExistingRevocationWithMostRecent(t *testing.T) {
+	cache := NewCache()
+
+	revData := make(map[string]interface{})
+	revData["value_hash"] = "hash"
+	revData["revoked_at"] = 123
+	revData["names"] = "c1"
+	revData["issued_before"] = 123
+
+	rev1 := &Revocation{Type: REVOCATION_TYPE_CLAIM, Data: revData}
+	cache.Add(rev1)
+
+	revData2 := make(map[string]interface{})
+	revData2["value_hash"] = "hash"
+	revData2["names"] = "c1"
+	revData2["revoked_at"] = 124
+	revData2["issued_before"] = 124
+	rev2 := &Revocation{Type: REVOCATION_TYPE_CLAIM, Data: revData2}
+	cache.Add(rev2)
+
+	storedData := cache.Get("hash")
+
+	if storedData.(*Revocation).Data["issued_before"].(int) == 123 {
+		t.Errorf("Should override existing revocation with same claim and newer issued_before.")
+	}
+}
+
 // vim: ts=4 sw=4 noexpandtab nolist syn=go


### PR DESCRIPTION
- older revocations claims with same hash cannot override newer ones
- test-case demonstrating the issue