### PR TITLE
 #67 Update to jwt-go 3.0.0

### DIFF
--- a/handlers/tokeninfo/jwt/handler.go
+++ b/handlers/tokeninfo/jwt/handler.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/rcrowley/go-metrics"
 	"github.com/zalando/planb-tokeninfo/handlers/tokeninfo"
 	"github.com/zalando/planb-tokeninfo/keyloader"
 	"github.com/zalando/planb-tokeninfo/revoke"
+	"github.com/dgrijalva/jwt-go/request"
 )
 
 type jwtHandler struct {
@@ -48,7 +48,7 @@ func (h *jwtHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var tie tokeninfo.Error
 	switch err {
-	case jwt.ErrNoTokenInRequest:
+	case request.ErrNoTokenInRequest:
 		tie = tokeninfo.ErrInvalidRequest
 	default:
 		tie = tokeninfo.ErrInvalidToken
@@ -59,7 +59,7 @@ func (h *jwtHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (h *jwtHandler) validateToken(req *http.Request) (*TokenInfo, error) {
 	start := time.Now()
-	token, err := jwt.ParseFromRequest(req, jwtValidator(h.keyLoader))
+	token, err := request.ParseFromRequest(req, request.OAuth2Extractor, jwtValidator(h.keyLoader))
 	if err != nil {
 		log.Println("Failed to validate token: ", err)
 		return nil, err

--- a/handlers/tokeninfo/jwt/tokeninfo.go
+++ b/handlers/tokeninfo/jwt/tokeninfo.go
@@ -93,11 +93,13 @@ func newTokenInfo(t *jwt.Token, timeBase time.Time) (*TokenInfo, error) {
 	}
 
 	clientId := ""
-	_, has := t.Claims[jwtClaimAzp]
-	if has {
-		clientId, ok = claimAsString(t, jwtClaimAzp)
-		if !ok {
-			return nil, ErrInvalidClaimAzp
+	if claims, ok := t.Claims.(jwt.MapClaims); ok {
+		_, has := claims[jwtClaimAzp]
+		if has {
+			clientId, ok = claimAsString(t, jwtClaimAzp)
+			if !ok {
+				return nil, ErrInvalidClaimAzp
+			}
 		}
 	}
 
@@ -164,10 +166,14 @@ func claimAsInt64(t *jwt.Token, claim string) (int64, bool) {
 }
 
 func getClaim(t *jwt.Token, claim string) (interface{}, bool) {
-	c, has := t.Claims[claim]
-	if !has {
-		log.Printf("Missing claim %q for token %v", claim, t.Raw)
-		return "", false
+	if claims, ok := t.Claims.(jwt.MapClaims); ok {
+		c, has := claims[claim]
+		if !has {
+			log.Printf("Missing claim %q for token %v", claim, t.Raw)
+			return "", false
+		}
+		return c, true
 	}
-	return c, true
+	log.Printf("Missing claim %q for token %v", claim, t.Raw)
+	return "", false
 }

--- a/handlers/tokeninfo/jwt/tokeninfo_test.go
+++ b/handlers/tokeninfo/jwt/tokeninfo_test.go
@@ -16,14 +16,14 @@ func TestTokenInfo(t *testing.T) {
 		wantError bool
 	}{
 		{jwt.Token{}, nil, true},
-		{jwt.Token{Claims: map[string]interface{}{"scope": "uid"}}, nil, true},
-		{jwt.Token{Claims: map[string]interface{}{"scope": []interface{}{"uid"}}}, nil, true},
-		{jwt.Token{Claims: map[string]interface{}{"scope": []interface{}{"uid"}, "sub": 42}}, nil, true},
-		{jwt.Token{Claims: map[string]interface{}{"scope": []interface{}{"uid"}, "sub": "foo"}}, nil, true},
-		{jwt.Token{Claims: map[string]interface{}{"scope": []interface{}{"uid"}, "sub": "foo", "realm": "/test"}}, nil, true},
-		{jwt.Token{Claims: map[string]interface{}{"scope": []interface{}{}, "sub": "foo", "realm": "/test", "azp": 123}}, nil, true},
+		{jwt.Token{Claims: jwt.MapClaims{"scope": "uid"}}, nil, true},
+		{jwt.Token{Claims: jwt.MapClaims{"scope": []interface{}{"uid"}}}, nil, true},
+		{jwt.Token{Claims: jwt.MapClaims{"scope": []interface{}{"uid"}, "sub": 42}}, nil, true},
+		{jwt.Token{Claims: jwt.MapClaims{"scope": []interface{}{"uid"}, "sub": "foo"}}, nil, true},
+		{jwt.Token{Claims: jwt.MapClaims{"scope": []interface{}{"uid"}, "sub": "foo", "realm": "/test"}}, nil, true},
+		{jwt.Token{Claims: jwt.MapClaims{"scope": []interface{}{}, "sub": "foo", "realm": "/test", "azp": 123}}, nil, true},
 		{
-			jwt.Token{Claims: map[string]interface{}{
+			jwt.Token{Claims: jwt.MapClaims{
 				"scope": []interface{}{"uid"},
 				"sub":   "foo",
 				"realm": "/test",
@@ -31,7 +31,7 @@ func TestTokenInfo(t *testing.T) {
 			nil,
 			true},
 		{
-			jwt.Token{Claims: map[string]interface{}{
+			jwt.Token{Claims: jwt.MapClaims{
 				"scope": []interface{}{"uid"},
 				"sub":   "foo",
 				"realm": "/test",
@@ -39,7 +39,7 @@ func TestTokenInfo(t *testing.T) {
 			nil,
 			true},
 		{
-			jwt.Token{Claims: map[string]interface{}{
+			jwt.Token{Claims: jwt.MapClaims{
 				"scope": []interface{}{"uid"},
 				"sub":   "foo",
 				"realm": "/test",
@@ -53,7 +53,7 @@ func TestTokenInfo(t *testing.T) {
 				ExpiresIn: 1},
 			false},
 		{
-			jwt.Token{Claims: map[string]interface{}{
+			jwt.Token{Claims: jwt.MapClaims{
 				"scope": []interface{}{},
 				"sub":   "foo",
 				"realm": "/test",

--- a/revoke/revokeprovider_test.go
+++ b/revoke/revokeprovider_test.go
@@ -77,7 +77,7 @@ func TestIsJWTRevoked(t *testing.T) {
 	crp.cache.Add(rev4)
 
 	// revoke a token
-	tc := make(map[string]interface{})
+	tc := jwt.MapClaims{}
 	tc[sub] = subVal
 	tc["iat"] = 400000.0
 	jt := &jwt.Token{Raw: rawJwt, Claims: tc}
@@ -135,7 +135,7 @@ func TestIsJWTRevoked(t *testing.T) {
 	}
 
 	// missing 'iat'
-	inv := make(map[string]interface{})
+	inv := jwt.MapClaims{}
 	inv[sub] = subVal
 	jt = &jwt.Token{Raw: rawJwt, Claims: inv}
 	if crp.IsJWTRevoked(jt) {
@@ -143,11 +143,17 @@ func TestIsJWTRevoked(t *testing.T) {
 	}
 
 	// missing 'sub'
-	inv = make(map[string]interface{})
+	inv = jwt.MapClaims{}
 	inv["iat"] = 150000.0
 	jt = &jwt.Token{Raw: rawJwt, Claims: inv}
 	if crp.IsJWTRevoked(jt) {
 		t.Errorf("Token should not be revoked (missing 'sub' claim)")
+	}
+
+	// Test JWT with nil claims
+	jt = &jwt.Token{}
+	if crp.IsJWTRevoked(jt) {
+		t.Errorf("Claim should not be revoked. %#v", jt)
 	}
 
 }
@@ -182,7 +188,7 @@ func TestIsJWTRevokedMissingCacheFields(t *testing.T) {
 	crp.cache.Add(rev3)
 
 	// token
-	tc := make(map[string]interface{})
+	tc := jwt.MapClaims{}
 	tc[sub] = subVal
 	tc["iat"] = 200000.0
 	jt := &jwt.Token{Raw: rawJwt, Claims: tc}
@@ -490,7 +496,7 @@ func benchmarkIsJWTRevoked(i int, cNames []string, b *testing.B) {
 	crp := NewCachingRevokeProvider(u)
 
 	for uid := 1; uid <= i; uid++ {
-		rd := make(map[string]interface{})
+		rd := jwt.MapClaims{}
 		rd["value_hash"] = strconv.Itoa(uid)
 		rd["names"] = cNames[uid%len(cNames)]
 		rd["revoked_at"] = int(time.Now().Unix())
@@ -498,7 +504,7 @@ func benchmarkIsJWTRevoked(i int, cNames []string, b *testing.B) {
 		crp.cache.Add(&Revocation{Type: REVOCATION_TYPE_CLAIM, Data: rd})
 	}
 
-	jc := make(map[string]interface{})
+	jc := jwt.MapClaims{}
 	jc["uid"] = "UserId"
 	jc["realm"] = "/customers"
 	jc["scope"] = "[uid]"


### PR DESCRIPTION
 - migrated claims using map[string]interface to MapClaims interface
 - added nil checks for MapClaim in the token when retrieving claims
 - added tests for token revocation with nil claims (should not be revoked)