### PR TITLE
 Pass tokens to upstream only if it matches a UUID

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,8 @@ The following environment variables are supported:
     Maximum number of entries for upstream token cache. It defaults to 10000.
 ``UPSTREAM_CACHE_TTL``
     The TTL for upstream token cache entries. It defaults to 60 seconds. Zero will disable the cache. See also `Time based settings`_
+``UPSTREAM_UUID_TOKENS``
+    The upstream uses tokens which look like UUIDs, e.g. like "df79b952-5192-44ca-b8db-acdfdef4d7e0", default is "false".
 ``REVOCATION_PROVIDER_URL``
     URL of of the Revocation service.
 ``REVOCATION_PROVIDER_REFRESH_INTERVAL``

--- a/README.rst
+++ b/README.rst
@@ -82,8 +82,9 @@ The following environment variables are supported:
     Maximum number of entries for upstream token cache. It defaults to 10000.
 ``UPSTREAM_CACHE_TTL``
     The TTL for upstream token cache entries. It defaults to 60 seconds. Zero will disable the cache. See also `Time based settings`_
-``UPSTREAM_UUID_TOKENS``
-    The upstream uses tokens which look like UUIDs, e.g. like "df79b952-5192-44ca-b8db-acdfdef4d7e0", default is "false".
+``UPSTREAM_TOKEN_REGEXP``
+    The upstream uses tokens which match this (POSIX) regexp, default is to accept any token for upstream. Tokens not
+    matching this regexp will be responsed with a default error and not passed to upstream.
 ``REVOCATION_PROVIDER_URL``
     URL of of the Revocation service.
 ``REVOCATION_PROVIDER_REFRESH_INTERVAL``

--- a/handlers/tokeninfo/proxy/handler.go
+++ b/handlers/tokeninfo/proxy/handler.go
@@ -23,8 +23,8 @@ type tokenInfoProxyHandler struct {
 }
 
 // NewTokenInfoProxyHandler returns an tokeninfo.Handler that proxies every Request to the server
-// at the upstreamURL when the env var UPSTREAM_TOKEN_REGEXP  is unset. When set to a POSIX regexp
-// value the upstreamURL will just get tokens which match this regexp.
+// at the upstreamURL when the env var UPSTREAM_TOKEN_REGEXP is unset. When set to a POSIX regexp
+// value it will just proxy requests where the token match.
 func NewTokenInfoProxyHandler(upstreamURL *url.URL, cacheMaxSize int64, cacheTTL time.Duration) tokeninfo.Handler {
 	log.Printf("Upstream tokeninfo is %s with %v cache (%d max size)", upstreamURL, cacheTTL, cacheMaxSize)
 	p := httputil.NewSingleHostReverseProxy(upstreamURL)

--- a/handlers/tokeninfo/proxy/handler.go
+++ b/handlers/tokeninfo/proxy/handler.go
@@ -22,8 +22,9 @@ type tokenInfoProxyHandler struct {
 	cacheTTL time.Duration
 }
 
-// NewTokenInfoProxyHandler returns an http.Handler that proxies every Request to the server
-// at the upstreamURL
+// NewTokenInfoProxyHandler returns an tokeninfo.Handler that proxies every Request to the server
+// at the upstreamURL when the env var UPSTREAM_UUID_TOKENS is set to false. When set to a true
+// value the upstreamURL will just get tokens which look like a UUID
 func NewTokenInfoProxyHandler(upstreamURL *url.URL, cacheMaxSize int64, cacheTTL time.Duration) tokeninfo.Handler {
 	log.Printf("Upstream tokeninfo is %s with %v cache (%d max size)", upstreamURL, cacheTTL, cacheMaxSize)
 	p := httputil.NewSingleHostReverseProxy(upstreamURL)

--- a/handlers/tokeninfo/proxy/handler.go
+++ b/handlers/tokeninfo/proxy/handler.go
@@ -135,35 +135,12 @@ func hostModifier(upstreamURL *url.URL, original func(req *http.Request)) func(r
 }
 
 func (h *tokenInfoProxyHandler) Match(req *http.Request) bool {
-	if !options.AppSettings.UpstreamHasUUIDTokens {
-		return true
-	}
 	token := tokeninfo.AccessTokenFromRequest(req)
 	if token == "" {
 		return false
 	}
-	if len(token) != 36 {
-		return false
+	if options.AppSettings.UpstreamTokenRegexp == nil {
+		return true
 	}
-	for i, c := range token {
-		// 82fb6428-767d-411e-a3a1-6c6007a15df4
-		// 012345678901234567890123456789012345
-		//           1         2         3
-		switch i {
-		case 8, 13, 18, 23:
-			if c != '-' {
-				return false
-			}
-		default:
-			switch {
-			case c < '0':
-				return false
-			case c > '9' && c < 'a':
-				return false
-			case c > 'f':
-				return false
-			}
-		}
-	}
-	return true
+	return options.AppSettings.UpstreamTokenRegexp.MatchString(token)
 }

--- a/handlers/tokeninfo/proxy/handler.go
+++ b/handlers/tokeninfo/proxy/handler.go
@@ -23,8 +23,8 @@ type tokenInfoProxyHandler struct {
 }
 
 // NewTokenInfoProxyHandler returns an tokeninfo.Handler that proxies every Request to the server
-// at the upstreamURL when the env var UPSTREAM_UUID_TOKENS is set to false. When set to a true
-// value the upstreamURL will just get tokens which look like a UUID
+// at the upstreamURL when the env var UPSTREAM_TOKEN_REGEXP  is unset. When set to a POSIX regexp
+// value the upstreamURL will just get tokens which match this regexp.
 func NewTokenInfoProxyHandler(upstreamURL *url.URL, cacheMaxSize int64, cacheTTL time.Duration) tokeninfo.Handler {
 	log.Printf("Upstream tokeninfo is %s with %v cache (%d max size)", upstreamURL, cacheTTL, cacheMaxSize)
 	p := httputil.NewSingleHostReverseProxy(upstreamURL)

--- a/handlers/tokeninfo/proxy/handler_test.go
+++ b/handlers/tokeninfo/proxy/handler_test.go
@@ -232,6 +232,9 @@ func TestRoutingMatchUUID(t *testing.T) {
 		{"http://example.com/oauth2/tokeninfo?access_token=header.claims.signature", false},
 		{"http://example.com/oauth1/tokeninfo?access_token=df79b952-5192-44ca-b8db-acdfdef4d7e0", true},
 		{"http://example.com/oauth1/tokeninfo?access_token=Xf79b952-5192-44ca-b8db-acdfdef4d7e0", false},
+		{"http://example.com/oauth1/tokeninfo?access_token=dfX9b952-5192-44ca-b8db-acdfdef4d7e0", false},
+		{"http://example.com/oauth1/tokeninfo?access_token=df79b952X5192-44ca-b8db-acdfdef4d7e0", false},
+		{"http://example.com/oauth1/tokeninfo?access_token=df79b95/-5192-44ca-b8db-acdfdef4d7e0", false},
 	} {
 		req, _ := http.NewRequest("GET", test.url, nil)
 		match := h.Match(req)

--- a/handlers/tokeninfo/proxy/handler_test.go
+++ b/handlers/tokeninfo/proxy/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"testing"
 	"time"
 
@@ -209,8 +210,8 @@ func TestUpstreamTimeout(t *testing.T) {
 	}
 }
 
-func TestRoutingMatchUUID(t *testing.T) {
-	options.AppSettings.UpstreamHasUUIDTokens = true
+func TestRoutingMatchRegexp(t *testing.T) {
+	options.AppSettings.UpstreamTokenRegexp = regexp.MustCompilePOSIX(`^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$`)
 	handler := func(w http.ResponseWriter, req *http.Request) {
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -245,7 +246,7 @@ func TestRoutingMatchUUID(t *testing.T) {
 	}
 }
 func TestRoutingMatchDefault(t *testing.T) {
-	options.AppSettings.UpstreamHasUUIDTokens = false
+	options.AppSettings.UpstreamTokenRegexp = nil
 	handler := func(w http.ResponseWriter, req *http.Request) {
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -261,8 +262,8 @@ func TestRoutingMatchDefault(t *testing.T) {
 		url  string
 		want bool
 	}{
-		{"http://example.com/oauth2/tokeninfo", true},
-		{"http://example.com/oauth2/tokeninfo?access_token", true},
+		{"http://example.com/oauth2/tokeninfo", false},
+		{"http://example.com/oauth2/tokeninfo?access_token", false},
 		{"http://example.com/oauth2/tokeninfo?access_token=foo", true},
 		{"http://example.com/oauth2/tokeninfo?access_token=header.claims.signature", true},
 		{"http://example.com/oauth1/tokeninfo?access_token=df79b952-5192-44ca-b8db-acdfdef4d7e0", true},

--- a/handlers/tokeninfo/unknown/handler.go
+++ b/handlers/tokeninfo/unknown/handler.go
@@ -1,0 +1,32 @@
+package unknownhandler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/rcrowley/go-metrics"
+	"github.com/zalando/planb-tokeninfo/handlers/tokeninfo"
+)
+
+type unknownHandler struct{}
+
+// New returns an http.Handler that is able to validate JWT tokens
+func New() http.Handler {
+	return &unknownHandler{}
+}
+
+// ServeHTTP will validate the JWT token in the Request and send back the TokenInfo in case
+// of success or the appropriate error messages otherwise. Both are sent in JSON.
+func (h *unknownHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	registerError(tokeninfo.ErrInvalidToken)
+	tokeninfo.ErrInvalidToken.Write(w)
+}
+
+func registerError(err tokeninfo.Error) {
+	key := fmt.Sprintf("planb.tokeninfo.unknown.errors.%s", err.Error)
+	if c, ok := metrics.DefaultRegistry.GetOrRegister(key, metrics.NewCounter).(metrics.Counter); ok {
+		c.Inc(1)
+	}
+}

--- a/handlers/tokeninfo/unknown/handler_test.go
+++ b/handlers/tokeninfo/unknown/handler_test.go
@@ -1,0 +1,42 @@
+package unknownhandler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestHandler(t *testing.T) {
+	h := New()
+
+	for _, test := range []struct {
+		token    string
+		wantCode int
+		wantBody string
+	}{
+		{"", http.StatusBadRequest, `{"error":"invalid_token","error_description":"Access Token not valid"}` + "\n"},
+		{"foo", http.StatusBadRequest, `{"error":"invalid_token","error_description":"Access Token not valid"}` + "\n"},
+	} {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "http://example.com/oauth2/tokeninfo?access_token="+test.token, nil)
+		h.ServeHTTP(w, req)
+
+		if test.wantCode != w.Code {
+			t.Errorf("Wrong status code. Wanted %d, got %d", test.wantCode, w.Code)
+		}
+
+		if !strings.Contains(w.Body.String(), test.wantBody) {
+			t.Errorf("Wrong response body. Wanted %q, got %q", test.wantBody, w.Body.String())
+		}
+	}
+}
+
+func TestHandlerCreation(t *testing.T) {
+	h := New()
+	_, ok := h.(*unknownHandler)
+	if !ok {
+		t.Fatalf("Wrong type for the handler = %v", reflect.TypeOf(h))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zalando/planb-tokeninfo/handlers/tokeninfo"
 	"github.com/zalando/planb-tokeninfo/handlers/tokeninfo/jwt"
 	"github.com/zalando/planb-tokeninfo/handlers/tokeninfo/proxy"
+	"github.com/zalando/planb-tokeninfo/handlers/tokeninfo/unknown"
 	"github.com/zalando/planb-tokeninfo/ht"
 	"github.com/zalando/planb-tokeninfo/keyloader/openid"
 	"github.com/zalando/planb-tokeninfo/options"
@@ -44,10 +45,11 @@ func main() {
 	kl := openid.NewCachingOpenIDProviderLoader(settings.OpenIDProviderConfigurationURL)
 	crp := revoke.NewCachingRevokeProvider(settings.RevocationProviderUrl)
 	jh := jwthandler.New(kl, crp)
+	uh := unknownhandler.New()
 
 	mux := http.NewServeMux()
 	mux.Handle("/health", healthcheck.NewHandler(kl, version))
-	mux.Handle("/oauth2/tokeninfo", tokeninfo.NewHandler(ph, jh))
+	mux.Handle("/oauth2/tokeninfo", tokeninfo.NewHandler(uh, jh, ph))
 	mux.Handle("/oauth2/connect/keys", jwks.NewHandler(kl))
 	log.Fatal(http.ListenAndServe(settings.ListenAddress, mux))
 }

--- a/options/options.go
+++ b/options/options.go
@@ -15,6 +15,7 @@ type Settings struct {
 	UpstreamTokenInfoURL              *url.URL
 	UpstreamCacheMaxSize              int64
 	UpstreamCacheTTL                  time.Duration
+	UpstreamHasUUIDTokens             bool
 	OpenIDProviderConfigurationURL    *url.URL
 	OpenIDProviderRefreshInterval     time.Duration
 	HTTPClientTimeout                 time.Duration
@@ -66,6 +67,7 @@ func defaultSettings() *Settings {
 // variables are:
 //
 //      UPSTREAM_TOKENINFO_URL
+//      UPSTREAM_UUID_TOKENS
 //      OPENID_PROVIDER_CONFIGURATION_URL
 //	REVOCATION_PROVIDER_URL
 //
@@ -112,6 +114,10 @@ func LoadFromEnvironment() error {
 
 	if d := getDuration("OPENID_PROVIDER_REFRESH_INTERVAL", 0); d > 0 {
 		settings.OpenIDProviderRefreshInterval = d
+	}
+
+	if b := getBoolean("UPSTREAM_UUID_TOKENS", false); b {
+		settings.UpstreamHasUUIDTokens = true
 	}
 
 	if d := getDuration("HTTP_CLIENT_TIMEOUT", 0); d > 0 {
@@ -164,6 +170,18 @@ func getInt(v string, def int) int {
 		return def
 	}
 	return i
+}
+
+func getBoolean(v string, def bool) bool {
+	s, ok := os.LookupEnv(v)
+	if !ok {
+		return def
+	}
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return def
+	}
+	return b
 }
 
 func getDuration(v string, def time.Duration) time.Duration {

--- a/options/options.go
+++ b/options/options.go
@@ -179,15 +179,7 @@ func getRegexp(v string, def *regexp.Regexp) (re *regexp.Regexp, err error) {
 	if !ok {
 		return def, nil
 	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("%s", r)
-			re = def
-		}
-	}()
-
-	re = regexp.MustCompilePOSIX(s)
-	return
+	return regexp.CompilePOSIX(s)
 }
 
 func getDuration(v string, def time.Duration) time.Duration {

--- a/options/options.go
+++ b/options/options.go
@@ -67,7 +67,6 @@ func defaultSettings() *Settings {
 // variables are:
 //
 //      UPSTREAM_TOKENINFO_URL
-//      UPSTREAM_UUID_TOKENS
 //      OPENID_PROVIDER_CONFIGURATION_URL
 //	REVOCATION_PROVIDER_URL
 //

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -30,6 +30,26 @@ func TestGetString(t *testing.T) {
 	}
 }
 
+func TestGetBool(t *testing.T) {
+	for _, test := range []struct {
+		def  bool
+		val  string
+		want bool
+	}{
+		{false, "false", false},
+		{false, "true", true},
+		{false, "1", true},
+		{false, "0", false},
+		{false, "", false},
+	} {
+		os.Clearenv()
+		os.Setenv("MYENV", test.val)
+		if s := getBoolean("MYENV", test.def); s != test.want {
+			t.Errorf("Failed to retrieve the correct value from the environment. Wanted %t, got %t", test.want, s)
+		}
+	}
+}
+
 func TestGetUrl(t *testing.T) {
 	for _, test := range []struct {
 		name      string


### PR DESCRIPTION
* ENV var to enable UPSTREAM_UUID_TOKENS=true
* default is to get all tokens after the JWT handler
* "unknown" handler just returns errors to client

